### PR TITLE
Add description and examples to some `core` keywords

### DIFF
--- a/content/2020-12/core/defs.markdown
+++ b/content/2020-12/core/defs.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "$defs"
 signature: "Object<String, Schema>"
-summary: "This keyword is used in meta-schemas to identify the required and optional vocabularies available for use in schemas described by that meta-schema."
+summary: "`$defs` in JSON Schema provides a standardized way to define reusable subschemas within a single schema document, promoting modularity, reducing code duplication, and improving schema organization. Each subschema within `$defs` has a unique name, acting as a pointer for referencing, without directly affecting validation; its value must be a valid JSON Schema."
 kind: [ "location" ]
 instance: [ "any" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4"
@@ -14,3 +14,60 @@ related:
   - vocabulary: core
     keyword: $dynamicRef
 ---
+
+## Examples
+
+{{<schema `Schema that describes the age of a person`>}}
+{
+  "type": "object",
+  "properties": {
+    "age": {
+      "$ref": "#/$defs/positiveInteger"
+    }
+  },
+  "$defs": {
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass `The instance has a valid "name" property that meets the requirement specified in the "$def" subschema`>}}
+{ "age": 25 }
+{{</instance-pass>}}
+
+{{<instance-fail `The value "0" is an integer, but it's not greater than or equal to 1, violating the "minimum" constraint of the "positiveInteger" subschema`>}}
+{ "age": 0 }
+
+{{</instance-fail>}}
+
+{{<schema `Schema for Product Data`>}}
+{
+  "type": "array",
+  "minItems": 1,
+  "items": { "$ref": "#/$defs/product" },
+    "$defs": {
+    "product": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "price": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass `The instance has a valid array of objects with product data as described in the "$def" subschema`>}}
+[
+  { "name": "T-shirt", "price": 19.99 },
+  { "name": "Mug", "price": 8.50 }
+]
+
+{{</instance-pass>}}
+
+{{<instance-fail `The array is empty, violating the "minItems" constraint requiring at least one product`>}}
+[]
+{{</instance-fail>}}

--- a/content/2020-12/core/id.markdown
+++ b/content/2020-12/core/id.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "$id"
 signature: "URI Reference"
-summary: 'The "$id" keyword declares an identifier for the schema and establishes the base URI for resolving other URI references within the schema. The "$id" keyword is resolved against the base URI of the overall object.'
+summary: 'The `$id` keyword declares an identifier for the schema and establishes the base URI for resolving other URI references within the schema. This keyword is resolved against the base URI of the overall object.'
 kind: ["identifier"]
 instance: ["any"]
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.1"
@@ -17,7 +17,7 @@ related:
 
 ## Examples
 
-{{<schema "Declaring an Identifier for the Schema">}}
+{{<schema `Declaring an Identifier for the Schema`>}}
 {
   "$id": "http://example.com/schemas/address.json",
   "type": "object",
@@ -30,7 +30,7 @@ related:
 -  _The __$id__ keyword declares the identifier "http://example.com/schemas/address.json" for the schema. This identifier can be used to reference the schema from other parts of the document or external documents._
 
 
-{{<schema "Establishing Base URI for Resolving References">}}
+{{<schema `Establishing Base URI for Resolving References`>}}
 {
   "$id": "https://example.com/main-schema",
   "type": "object",

--- a/content/2020-12/core/id.markdown
+++ b/content/2020-12/core/id.markdown
@@ -1,9 +1,9 @@
 ---
 keyword: "$id"
 signature: "URI Reference"
-summary: "This keyword declares an identifier for the schema resource."
-kind: [ "identifier" ]
-instance: [ "any" ]
+summary: 'The "$id" keyword declares an identifier for the schema and establishes the base URI for resolving other URI references within the schema. The "$id" keyword is resolved against the base URI of the overall object.'
+kind: ["identifier"]
+instance: ["any"]
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.1"
 metaschema: "https://json-schema.org/draft/2020-12/meta/core"
 index: -999
@@ -14,3 +14,48 @@ related:
   - vocabulary: core
     keyword: $vocabulary
 ---
+
+## Examples
+
+{{<schema "Declaring an Identifier for the Schema">}}
+{
+  "$id": "http://example.com/schemas/address.json",
+  "type": "object",
+  "properties": {
+    "street_address": { "type": "string" },
+    "city": { "type": "string" }
+  }
+}
+{{</schema>}}
+-  _The __$id__ keyword declares the identifier "http://example.com/schemas/address.json" for the schema. This identifier can be used to reference the schema from other parts of the document or external documents._
+
+
+{{<schema "Establishing Base URI for Resolving References">}}
+{
+  "$id": "https://example.com/main-schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "address": {
+      "$ref": "#/$defs/address"
+    }
+  },
+  "$defs": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        }
+      },
+      "required": ["street", "city"]
+    }
+  }
+}
+{{</schema>}}
+-  _The __$ref__ keyword is used to reference the nested schema within __$defs__ ("#/$defs/address"). The base URI for resolving this reference is established by the __$id__ of the main schema ("https://example.com/main-schema"). The reference is resolved against the base URI, resulting in the fully resolved URI "https://example.com/main-schema#/$defs/address" for the referenced schema._

--- a/content/2020-12/core/ref.markdown
+++ b/content/2020-12/core/ref.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "$ref"
 signature: "URI Reference"
-summary: "This keyword is used to reference a statically identified schema."
+summary: "The ___$ref___ keyword is used to reference a statically identified schema. This is useful for avoiding code duplication and promoting modularity when describing complex data structures. The value of ___$ref___ can be either:  `Relative`, i.e., using JSON pointers starting with \"#/\" to reference other components within the same schema document, or `Absolute`, i.e., a full URI pointing to an external schema definition."
 kind: [ "applicator" ]
 instance: [ "any" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.3.1"
@@ -21,3 +21,70 @@ related:
   - vocabulary: core
     keyword: $defs
 ---
+
+## Examples
+
+{{<schema "Using a relative reference:" >}}
+{
+  "$id": "http://example.com/schemas/product.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["productId", "name"],
+  "properties": {
+    "productId": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass "Instance including all the required properties is valid" >}}
+{
+  "productId": 123,
+  "name": "Widget"
+}
+{{</instance-pass>}}
+
+{{<instance-fail "Instance missing the required properties is invalid" >}}
+{
+  "name": "Gadget"
+}
+{{</instance-fail>}}
+
+
+{{<schema "Using an absolute referece:" >}}
+{
+  "$id": "http://example.com/schemas/order.json",
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": { "$ref": "http://example.com/schemas/product.json" }
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass "Each item in the \"items\" array includes both the \"productId\" and \"name\" properties required by the referenced product schema" >}}
+{
+  "items": [
+    { "productId": 123, "name": "Widget" },
+    { "productId": 456, "name": "Gadget" }
+  ]
+}
+// Assuming http://example.com/schemas/product.json defines the product schema
+
+{{</instance-pass>}}
+
+{{<instance-fail "The first item is missing the \"productId\" property and the second item is missing the \"name\" property required by the product schema." >}}
+{
+  "items": [
+    { "name": "Widget" },
+    { "productId": 456 }
+  ]
+}
+
+{{</instance-fail>}}

--- a/content/2020-12/core/ref.markdown
+++ b/content/2020-12/core/ref.markdown
@@ -1,7 +1,7 @@
 ---
 keyword: "$ref"
 signature: "URI Reference"
-summary: "The ___$ref___ keyword is used to reference a statically identified schema. This is useful for avoiding code duplication and promoting modularity when describing complex data structures. The value of ___$ref___ can be either:  `Relative`, i.e., using JSON pointers starting with \"#/\" to reference other components within the same schema document, or `Absolute`, i.e., a full URI pointing to an external schema definition."
+summary: "The `$ref` keyword is used to reference a statically identified schema. This is useful for avoiding code duplication and promoting modularity when describing complex data structures. The value of `$ref` can be either:  ___Relative___, i.e., using JSON pointers starting with ___\"#/\"___ to reference other components within the same schema document, or ___Absolute___, i.e., a full URI pointing to an external schema definition."
 kind: [ "applicator" ]
 instance: [ "any" ]
 specification: "https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.3.1"
@@ -24,38 +24,46 @@ related:
 
 ## Examples
 
-{{<schema "Using a relative reference:" >}}
+{{<schema `Using a relative reference:` >}}
 {
   "$id": "http://example.com/schemas/product.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["productId", "name"],
+  "required": [
+    "productId",
+    "name"
+  ],
   "properties": {
     "productId": {
       "type": "integer"
     },
     "name": {
+      "$ref": "#/$defs/string"
+    }
+  },
+  "$defs": {
+    "string": {
       "type": "string"
     }
   }
 }
 {{</schema>}}
 
-{{<instance-pass "Instance including all the required properties is valid" >}}
+{{<instance-pass `Instance including all the required properties is valid` >}}
 {
   "productId": 123,
   "name": "Widget"
 }
 {{</instance-pass>}}
 
-{{<instance-fail "Instance missing the required properties is invalid" >}}
+{{<instance-fail `Instance missing the required properties is invalid` >}}
 {
   "name": "Gadget"
 }
 {{</instance-fail>}}
 
 
-{{<schema "Using an absolute referece:" >}}
+{{<schema `Using an absolute referece:` >}}
 {
   "$id": "http://example.com/schemas/order.json",
   "type": "object",
@@ -68,7 +76,7 @@ related:
 }
 {{</schema>}}
 
-{{<instance-pass "Each item in the \"items\" array includes both the \"productId\" and \"name\" properties required by the referenced product schema" >}}
+{{<instance-pass `Each item in the "items" array includes both the "productId" and "name" properties required by the referenced product schema` >}}
 {
   "items": [
     { "productId": 123, "name": "Widget" },
@@ -79,7 +87,7 @@ related:
 
 {{</instance-pass>}}
 
-{{<instance-fail "The first item is missing the \"productId\" property and the second item is missing the \"name\" property required by the product schema." >}}
+{{<instance-fail `The first item is missing the "productId" property and the second item is missing the "name" property required by the product schema.` >}}
 {
   "items": [
     { "name": "Widget" },

--- a/content/2020-12/core/schema.markdown
+++ b/content/2020-12/core/schema.markdown
@@ -16,3 +16,17 @@ related:
   - vocabulary: core
     keyword: $defs
 ---
+
+## Examples
+
+{{<schema "This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 2020-12">}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}
+{{</schema>}}
+
+{{<schema "This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 7">}}
+{
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}
+{{</schema>}}

--- a/content/2020-12/core/schema.markdown
+++ b/content/2020-12/core/schema.markdown
@@ -19,13 +19,13 @@ related:
 
 ## Examples
 
-{{<schema "This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 2020-12">}}
+{{<schema `This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 2020-12`>}}
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema"
 }
 {{</schema>}}
 
-{{<schema "This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 7">}}
+{{<schema `This declaration indicates that the schema follows the specifications outlined in JSON Schema Draft 7`>}}
 {
   "$schema": "http://json-schema.org/draft-07/schema#"
 }


### PR DESCRIPTION
This PR adds description and examples for `$id`, `$schema`, `$ref` and `$defs` keywords of `core` vocab.