### PR TITLE
Keyword `title`

### DIFF
--- a/content/2020-12/meta-data/title.markdown
+++ b/content/2020-12/meta-data/title.markdown
@@ -51,7 +51,7 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
   "valid": true,
   "keywordLocation": "/title",
   "instanceLocation": "",
-  "annotations": "Age of a person"
+  "annotation": "Age of a person"
 }
 {{</instance-annotation>}}
 
@@ -99,49 +99,31 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
     "valid": true,
     "keywordLocation": "/title",
     "instanceLocation": "",
-    "annotations": "Personal Info"
-  },
-  {
-    "valid": true,
-    "keywordLocation": "/properties",
-    "instanceLocation": "",
-    "annotations": [ "name", "age" ]
+    "annotation": "Personal Info"
   },
   {
     "valid": true,
     "keywordLocation": "/if/title",
     "instanceLocation": "",
-    "annotations": "if block"
-  },
-  {
-    "valid": true,
-    "keywordLocation": "/if/properties",
-    "instanceLocation": "",
-    "annotations": [ "age" ]
+    "annotation": "if block"
   },
   {
     "valid": true,
     "keywordLocation": "/if/properties/age/title",
     "instanceLocation": "/age",
-    "annotations": "'if' true"
+    "annotation": "'if' true"
   },
   {
     "valid": true,
     "keywordLocation": "/then/title",
     "instanceLocation": "",
-    "annotations": "then block",
-  },
-  {
-    "valid": true,
-    "keywordLocation": "/then/properties",
-    "instanceLocation": "",
-    "annotations": [ "eligible" ]
+    "annotation": "then block",
   },
   {
     "valid": true,
     "keywordLocation": "/then/properties/eligible/title",
     "instanceLocation": "/eligible",
-    "annotations": "then applied"
+    "annotation": "then applied"
   },
   // ...
 ]
@@ -172,13 +154,13 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
     "valid": true,
     "keywordLocation": "/title",
     "instanceLocation": "",
-    "annotations": "Person's name"
+    "annotation": "Person's name"
   },
   {
     "valid": true,
     "keywordLocation": "/$ref/title",
     "instanceLocation": "",
-    "annotations": "Person's name"
+    "annotation": "Person's name"
   },
   // ...
 ]

--- a/content/2020-12/meta-data/title.markdown
+++ b/content/2020-12/meta-data/title.markdown
@@ -27,3 +27,165 @@ Annotations
 -----------
 
 This keyword produces the title as the annotation value.
+
+## Explanation
+
+The `title` keyword in JSON Schema is used to provide a human-readable label for a schema or its parts. It does not affect data validation but serves as an informative annotation. The value of this keyword must be a string.
+
+## Examples
+
+{{<schema `Schema with 'title' keyword`>}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Age of a person",
+  "type": "number"
+}
+{{</schema>}}
+
+{{<instance-pass `An instance with a numeric value is valid`>}}
+45
+{{</instance-pass>}}
+
+{{<instance-annotation>}}
+{
+  "valid": true,
+  "keywordLocation": "/",
+  "instanceLocation": "",
+  "annotations": {
+    "title": "Age of a person"
+  }
+}
+{{</instance-annotation>}}
+
+{{<schema `Schema with logical operators`>}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Personal Info",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "number" }
+  },
+  "if": {
+    "title": "if block",
+    "properties": {
+      "age": { "title": "'if' true", "minimum": 18 }
+    }
+  },
+  "then": {
+    "title": "then block",
+    "properties": {
+      "eligible": { "title": "then applied", "const": true }
+    }
+  },
+  "else": {
+    "title": "else block",
+    "properties": {
+      "eligible": { "title": "else applied", "const": false }
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass>}}
+{
+  "name": "John Doe",
+  "age": 25,
+  "eligible": true
+}
+{{</instance-pass>}}
+
+{{<instance-annotation>}}
+[
+  /// ...
+  {
+    "valid": true,
+    "keywordLocation": "/",
+    "instanceLocation": "",
+    "annotations": {
+      "title": "Personal Info",
+      "properties": [ "name", "age" ],
+      "if": true
+    }
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/if",
+    "instanceLocation": "",
+    "annotations": {
+      "title": "if block",
+      "properties": [
+        "age"
+      ]
+    }
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/if/properties/age",
+    "instanceLocation": "/age",
+    "annotations": {
+      "title": "'if' true"
+    }
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/then",
+    "instanceLocation": "",
+    "annotations": {
+      "title": "then block",
+      "properties": [
+        "eligible"
+      ]
+    }
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/then/properties/eligible",
+    "instanceLocation": "/eligible",
+    "annotations": {
+      "title": "then applied"
+    }
+  },
+  // ...
+]
+{{</instance-annotation>}}
+
+{{<schema `Schema with multiple annotations for the same instance`>}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Person's name",
+  "$ref": "#/$defs/name",
+  "$defs": {
+    "name": {
+      "title": "Person's name",
+      "type": "string"
+    }
+  }
+}
+{{</schema>}}
+
+{{<instance-pass>}}
+"John Doe"
+{{</instance-pass>}}
+
+{{<instance-annotation>}}
+[
+  // ...
+  {
+    "valid": true,
+    "keywordLocation": "/",
+    "instanceLocation": "",
+    "annotations": {
+      "title": "Person's name"
+    }
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/$ref",
+    "instanceLocation": "",
+    "annotations": {
+      "title": "Person's name"
+    }
+  },
+  // ...
+]
+{{</instance-annotation>}}

--- a/content/2020-12/meta-data/title.markdown
+++ b/content/2020-12/meta-data/title.markdown
@@ -49,11 +49,9 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
 {{<instance-annotation>}}
 {
   "valid": true,
-  "keywordLocation": "/",
+  "keywordLocation": "/title",
   "instanceLocation": "",
-  "annotations": {
-    "title": "Age of a person"
-  }
+  "annotations": "Age of a person"
 }
 {{</instance-annotation>}}
 
@@ -99,51 +97,51 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
   /// ...
   {
     "valid": true,
-    "keywordLocation": "/",
+    "keywordLocation": "/title",
     "instanceLocation": "",
-    "annotations": {
-      "title": "Personal Info",
-      "properties": [ "name", "age" ],
-      "if": true
-    }
+    "annotations": "Personal Info"
   },
   {
     "valid": true,
-    "keywordLocation": "/if",
+    "keywordLocation": "/properties",
     "instanceLocation": "",
-    "annotations": {
-      "title": "if block",
-      "properties": [
-        "age"
-      ]
-    }
+    "annotations": [ "name", "age" ]
   },
   {
     "valid": true,
-    "keywordLocation": "/if/properties/age",
+    "keywordLocation": "/if/title",
+    "instanceLocation": "",
+    "annotations": "if block"
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/if/properties",
+    "instanceLocation": "",
+    "annotations": [ "age" ]
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/if/properties/age/title",
     "instanceLocation": "/age",
-    "annotations": {
-      "title": "'if' true"
-    }
+    "annotations": "'if' true"
   },
   {
     "valid": true,
-    "keywordLocation": "/then",
+    "keywordLocation": "/then/title",
     "instanceLocation": "",
-    "annotations": {
-      "title": "then block",
-      "properties": [
-        "eligible"
-      ]
-    }
+    "annotations": "then block",
   },
   {
     "valid": true,
-    "keywordLocation": "/then/properties/eligible",
-    "instanceLocation": "/eligible",
-    "annotations": {
-      "title": "then applied"
-    }
+    "keywordLocation": "/then/properties",
+    "instanceLocation": "",
+    "annotations": [ "eligible" ]
+  },
+  {
+    "valid": true,
+    "keywordLocation": "/then/properties/eligible/title",
+    "instanceLocation": "",
+    "annotations": "then applied"
   },
   // ...
 ]
@@ -172,19 +170,15 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
   // ...
   {
     "valid": true,
-    "keywordLocation": "/",
+    "keywordLocation": "/title",
     "instanceLocation": "",
-    "annotations": {
-      "title": "Person's name"
-    }
+    "annotations": "Person's name"
   },
   {
     "valid": true,
-    "keywordLocation": "/$ref",
+    "keywordLocation": "/$ref/title",
     "instanceLocation": "",
-    "annotations": {
-      "title": "Person's name"
-    }
+    "annotations": "Person's name"
   },
   // ...
 ]

--- a/content/2020-12/meta-data/title.markdown
+++ b/content/2020-12/meta-data/title.markdown
@@ -140,7 +140,7 @@ The `title` keyword in JSON Schema is used to provide a human-readable label for
   {
     "valid": true,
     "keywordLocation": "/then/properties/eligible/title",
-    "instanceLocation": "",
+    "instanceLocation": "/eligible",
     "annotations": "then applied"
   },
   // ...

--- a/layouts/shortcodes/instance-annotation.html
+++ b/layouts/shortcodes/instance-annotation.html
@@ -1,0 +1,6 @@
+<div class="code code-instance bg-warning border">
+  <div class="d-flex align-items-center border-bottom">
+    <small class="px-2 py-1 border-end flex-grow-1"> Annotations</small>
+  </div>
+  {{ $code := trim .Inner "\n" }} {{ transform.Highlight ($code) "json" }}
+</div>


### PR DESCRIPTION
This PR addresses #71.

Please have a look at the last example and let me know whether I understood correctly what you meant to convey in issue #71.

Regarding the output format for annotations, I've maintained it as per the discussion in issue #133. Although you previously suggested replacing the ellipsis used in the annotation with the complete standard output, I haven't replaced it as the complete output would be too large. Please let me know your thoughts on this.
