### PR TITLE
Unify how we introduce keyword explanations

### DIFF
--- a/content/2020-12/applicator/additionalProperties.markdown
+++ b/content/2020-12/applicator/additionalProperties.markdown
@@ -41,8 +41,6 @@ related:
     keyword: unevaluatedProperties
 ---
 
-## Explanation
-
 The `additionalProperties` keyword is used to control the handling of properties whose names are not listed in the `properties` keyword or match any of the regular expressions in the `patternProperties` keyword. By default any additional properties are allowed.
 
 The behavior of this keyword depends on the presence and annotation results of `properties` and `patternProperties` within the same schema object. Validation with `additionalProperties` applies only to the child values of instance names that do not appear in the annotation results of either `properties` or `patternProperties`.

--- a/content/2020-12/applicator/contains.markdown
+++ b/content/2020-12/applicator/contains.markdown
@@ -35,8 +35,6 @@ related:
     keyword: unevaluatedItems
 ---
 
-## Explanation
-
 The `contains` keyword is used to check if at least one element in an array instance validates against a specified sub-schema. It offers flexibility compared to `items`, which requires all elements to adhere to a single schema.
 
 An array instance is valid against `contains` if at least one of its elements is valid against the given schema, except when `minContains` is present and has a value of 0, in which case an array instance must be considered valid against the `contains` keyword, even if none of its elements is valid against the given schema.

--- a/content/2020-12/applicator/items.markdown
+++ b/content/2020-12/applicator/items.markdown
@@ -38,8 +38,6 @@ related:
     keyword: unevaluatedItems
 ---
 
-## Explanation
-
 The `items` keyword is used to validate arrays of arbitrary length where each item in the array matches the same schema. It applies its subschema to all instance items at indexes greater than the length of the `prefixItems` array in the same schema, or to all instance array elements if `prefixItems` is not present. This means that the subschema specified under `items` will be used to validate every item in the array that isn't covered by `prefixItems`.
 
 If the `items` subschema is applied to any positions within the instance array, it produces an annotation result of boolean *true*, indicating that all remaining array elements have been evaluated against this keyword's subschema. This annotation affects the behavior of `unevaluatedItems` in the *Unevaluated* vocabulary.

--- a/content/2020-12/applicator/patternProperties.markdown
+++ b/content/2020-12/applicator/patternProperties.markdown
@@ -40,8 +40,6 @@ related:
     keyword: unevaluatedProperties
 ---
 
-## Explanation
-
 The `patternProperties` keyword is a variant of `properties` with regular expression support. It maps regular expressions to schemas. If a property name matches the given regular expression, the property value must validate against the corresponding schema.
 
 ## Examples

--- a/content/2020-12/applicator/prefixItems.markdown
+++ b/content/2020-12/applicator/prefixItems.markdown
@@ -37,13 +37,13 @@ related:
     keyword: unevaluatedItems
 ---
 
-## Explanation
-
 The `prefixItems` keyword is used to validate arrays by applying a schema to each corresponding index of the array. It differs from the `items` keyword in that it validates only a prefix of the array, up to the length of the `prefixItems` array. Each schema specified in `prefixItems` corresponds to an index in the input array.
 
 * The annotation produced by this keyword affects the behavior of `items` and `unevaluatedItems`.
 * `items` is used to validate all items in an array that are not covered by `prefixItems`, while `prefixItems` validates only a prefix of the array.
 * `prefixItems` keyword does not constrain the length of the array. If the array is longer than this keyword's value, this keyword validates only the prefix of matching length.
+
+## Examples
 
 {{<schema `Schema with 'prefixItems' keyword`>}}
 {

--- a/content/2020-12/applicator/properties.markdown
+++ b/content/2020-12/applicator/properties.markdown
@@ -40,8 +40,6 @@ related:
     keyword: unevaluatedProperties
 ---
 
-## Explanation
-
 The `properties` keyword is used to define the properties (keys) that an object instance must or may contain. It allows you to specify the expected value of a property in an object instance. Each property within the `properties` object is defined by its name and a subschema describing the value expected for that property if present.
 
 The annotation result of this keyword is the set of instance property names matched by this keyword. This annotation affects the behavior of `additionalProperties` and `unevaluatedProperties`.

--- a/content/2020-12/content/contentEncoding.markdown
+++ b/content/2020-12/content/contentEncoding.markdown
@@ -20,6 +20,12 @@ related:
     keyword: contentSchema
 ---
 
+The `contentEncoding` keyword is an annotation used to specify the encoding used to store the contents of a string, particularly when it represents binary data. It indicates how the string value should be interpreted and decoded. This keyword is not directly involved in the validation process but provides metadata about the content.
+
+* `contentEncoding` doesn't enforce strict validation. However, it's recommended to use it correctly to ensure compatibility with applications that might interpret the encoding.
+* It represents the type of binary encoding used for the string under question. Some of the common encodings are listed [here](#common-encodings).
+* The JSON Schema specification doesn't publish a predefined list of possible encodings
+
 ## Common Encodings
 
 | Encoding   | Description                                                                                     | Reference |
@@ -27,15 +33,6 @@ related:
 | `"base16"` | Encoding scheme for binary data using a 16-character hexadecimal alphabet                       | [RFC 4648 §8](https://datatracker.ietf.org/doc/html/rfc4648#section-8) |
 | `"base32"` | Encoding scheme for binary data using a 32-character hexadecimal alphabet                                   | [RFC 4648 §6](https://datatracker.ietf.org/doc/html/rfc4648#section-6) |
 | `"base64"` | Encoding scheme for binary data using a 64-character hexadecimal alphabet | [RFC 4648 §4](https://datatracker.ietf.org/doc/html/rfc4648#section-4) |
-
-
-## Explanation
-
-The `contentEncoding` keyword is an annotation used to specify the encoding used to store the contents of a string, particularly when it represents binary data. It indicates how the string value should be interpreted and decoded. This keyword is not directly involved in the validation process but provides metadata about the content.
-
-* `contentEncoding` doesn't enforce strict validation. However, it's recommended to use it correctly to ensure compatibility with applications that might interpret the encoding.
-* It represents the type of binary encoding used for the string under question. Some of the common encodings are listed [here](#common-encodings).
-* The JSON Schema specification doesn't publish a predefined list of possible encodings
 
 ## Examples
 

--- a/content/2020-12/content/contentMediaType.markdown
+++ b/content/2020-12/content/contentMediaType.markdown
@@ -21,8 +21,6 @@ related:
     keyword: contentEncoding
 ---
 
-## Explanation
-
 The `contentMediaType` keyword in JSON Schema specifies the MIME type of the contents of a string. It is used to annotate the type of media contained within a string. It should be noted that:
 
 * This keyword is purely an annotation and does not directly affect validation.

--- a/content/2020-12/content/contentSchema.markdown
+++ b/content/2020-12/content/contentSchema.markdown
@@ -23,8 +23,6 @@ related:
     keyword: contentEncoding
 ---
 
-## Explanation
-
 The `contentSchema` keyword allows you to specify a schema that describes the structure of the content within a string instance, particularly when used in conjunction with the `contentMediaType` keyword. This is useful when the string instance contains data conforming to the JSON data model.
 
 However, it's important to note that `contentSchema` is merely an annotation and is not directly involved in the validation process. Instead, applications that consume JSON Schemas must use this information as they see fit. `contentSchema` must be a valid JSON Schema, but it is ignored if `contentMediaType` is absent.

--- a/content/2020-12/format-annotation/format.markdown
+++ b/content/2020-12/format-annotation/format.markdown
@@ -18,6 +18,17 @@ related:
     keyword: format
 ---
 
+## Explanation
+
+The `format` keyword in JSON Schema's Format Annotation vocabulary serves to provide basic semantic identification of certain types of string values. Compared to older JSON Schema versions, the `format` keyword in the official 2020-12 dialect is purely an annotation meant to be informative and to carry semantics rather than to perform any validation.
+
+When using `format` from Format Annotation, it's recommended that you provide your validation rules alongside the `format`. The implementation may choose to treat `format` as an assertion and attempt to validate the value's conformance to the specified semantics. However, this behavior must be explicitly enabled and is typically disabled by default. Implementations should document their level of support for such validation.
+
+* `It allows for the semantic identification of certain kinds of string values. For instance, it can indicate that a string value should be interpreted as a date, email, URI, etc.
+* `format` is solely an annotation and does not enforce any validation. It's meant to provide information about the expected format of the string.
+* Implementations may choose to enable format as an assertion, meaning that validation fails if the value doesn't conform to the specified format semantics. However, this is not mandatory and must be explicitly enabled.
+* While users can define and use their own custom `formats` (e.g., "format": "foobar"), it's recommended to refrain from overloading the format keyword for future compatibility reasons. Instead, define custom keywords for specific validation requirements. For example in the event that you define your own "foobar" and JSON Schema subsequently chooses to define "foobar," you may encounter difficulties.
+
 Defined Formats
 ---------------
 
@@ -42,17 +53,6 @@ Defined Formats
 | `"json-pointer"`          | JSON Pointer         | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.7 |
 | `"relative-json-pointer"` | JSON Pointer         | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.7 |
 | `"regex"`                 | Regular Expressions  | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.8 |
-
-## Explanation
-
-The `format` keyword in JSON Schema's Format Annotation vocabulary serves to provide basic semantic identification of certain types of string values. Compared to older JSON Schema versions, the `format` keyword in the official 2020-12 dialect is purely an annotation meant to be informative and to carry semantics rather than to perform any validation.
-
-When using `format` from Format Annotation, it's recommended that you provide your validation rules alongside the `format`. The implementation may choose to treat `format` as an assertion and attempt to validate the value's conformance to the specified semantics. However, this behavior must be explicitly enabled and is typically disabled by default. Implementations should document their level of support for such validation.
-
-* `It allows for the semantic identification of certain kinds of string values. For instance, it can indicate that a string value should be interpreted as a date, email, URI, etc.
-* `format` is solely an annotation and does not enforce any validation. It's meant to provide information about the expected format of the string.
-* Implementations may choose to enable format as an assertion, meaning that validation fails if the value doesn't conform to the specified format semantics. However, this is not mandatory and must be explicitly enabled.
-* While users can define and use their own custom `formats` (e.g., "format": "foobar"), it's recommended to refrain from overloading the format keyword for future compatibility reasons. Instead, define custom keywords for specific validation requirements. For example in the event that you define your own "foobar" and JSON Schema subsequently chooses to define "foobar," you may encounter difficulties.
 
 ## Examples
 

--- a/content/2020-12/format-assertion/format.markdown
+++ b/content/2020-12/format-assertion/format.markdown
@@ -38,6 +38,12 @@ related:
     keyword: format
 ---
 
+## Explanation
+
+The `format` keyword of the "format-assertion" vocabulary allows for basic semantic identification of certain kinds of string values that are commonly used. It provides a way to specify logical formats for string types, such as dates, email addresses, URIs, etc. However, it's important to note that this vocabulary is not used by default in the official 2020-12 dialect of JSON Schema. If you want to utilize it, you would need to define your own custom dialect that includes this vocabulary.
+
+While the `format` keyword theoretically provides interoperable logical string type validation, many existing implementations may not support this vocabulary. Therefore, it's recommended to use the `format` keyword from the Format Annotation vocabulary (which is available out of the box) alongside any custom validation within the schema.
+
 Defined Formats
 ---------------
 
@@ -62,12 +68,6 @@ Defined Formats
 | `"json-pointer"`          | JSON Pointer         | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.7 |
 | `"relative-json-pointer"` | JSON Pointer         | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.7 |
 | `"regex"`                 | Regular Expressions  | https://json-schema.org/draft/2020-12/json-schema-validation.html#section-7.3.8 |
-
-## Explanation
-
-The `format` keyword of the "format-assertion" vocabulary allows for basic semantic identification of certain kinds of string values that are commonly used. It provides a way to specify logical formats for string types, such as dates, email addresses, URIs, etc. However, it's important to note that this vocabulary is not used by default in the official 2020-12 dialect of JSON Schema. If you want to utilize it, you would need to define your own custom dialect that includes this vocabulary.
-
-While the `format` keyword theoretically provides interoperable logical string type validation, many existing implementations may not support this vocabulary. Therefore, it's recommended to use the `format` keyword from the Format Annotation vocabulary (which is available out of the box) alongside any custom validation within the schema.
 
 ## Examples
 

--- a/content/2020-12/meta-data/default.markdown
+++ b/content/2020-12/meta-data/default.markdown
@@ -28,8 +28,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 The `default` keyword in JSON Schema is used to specify a default value for an instance. This value is not automatically used to fill in missing values during the validation process but can be used by tools such as documentation or form generators.
 
 _**Note:** While it is recommended that the default value validate against its subschema, this requirement is not strictly enforced._

--- a/content/2020-12/meta-data/deprecated.markdown
+++ b/content/2020-12/meta-data/deprecated.markdown
@@ -28,8 +28,6 @@ related:
     keyword: writeOnly
 ---
 
-## Explanation
-
 The `deprecated` keyword is used to indicate that a particular property should not be used and may be removed in the future. It provides a warning to users or applications that certain parts of the schema or are no longer recommended for use.
 
 * `deprecated` does not affect data validation but serves as an informative annotation.

--- a/content/2020-12/meta-data/description.markdown
+++ b/content/2020-12/meta-data/description.markdown
@@ -27,8 +27,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 The `description` keyword in JSON Schema is used to provide a human readable description for the schema. It does not affect data validation but serves as an informative annotation.
 
 ## Examples

--- a/content/2020-12/meta-data/examples.markdown
+++ b/content/2020-12/meta-data/examples.markdown
@@ -30,8 +30,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 The `examples` keyword is used to provide a list of example instances associated with a particular schema that should ideally validate against the schema. These examples serve to illustrate the intended structure and constraints defined by the schema. While these examples are not used for validation purposes, they are helpful in providing sample valid instances against the schema they are defined in.
 
 _**Note:** While it is recommended that the examples validate against the subschema they are defined in, this requirement is not strictly enforced._

--- a/content/2020-12/meta-data/readOnly.markdown
+++ b/content/2020-12/meta-data/readOnly.markdown
@@ -28,8 +28,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 The `readOnly` keyword is used to indicate that the value of a particular property is managed exclusively by the owning authority, and attempts by an application to modify the value of this property are expected to be ignored or rejected by that authority. It essentially means that the instance value should not be modified.
 
 It's important to note that this keyword doesn't imply the schema itself is writable; schemas must be treated as immutable. Instead, the keyword specifies instances where read/write operation semantics are use case specific.

--- a/content/2020-12/meta-data/title.markdown
+++ b/content/2020-12/meta-data/title.markdown
@@ -27,8 +27,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 The `title` keyword in JSON Schema is used to provide a human-readable label for a schema or its parts. It does not affect data validation but serves as an informative annotation.
 
 ## Examples

--- a/content/2020-12/meta-data/writeOnly.markdown
+++ b/content/2020-12/meta-data/writeOnly.markdown
@@ -28,8 +28,6 @@ related:
     keyword: deprecated
 ---
 
-## Explanation
-
 the `writeOnly` keyword is used to indicate that an instance value should be writable, but it won't be included when the instance is retrieved from the owning authority. It's important to note that this doesn't imply the schema itself is writable; schemas must be treated as immutable. Instead, the keyword specifies instances where read/write operation semantics are use case specific.
 
 * `writeOnly` does not affect data validation but serves as an informative annotation.

--- a/content/2020-12/unevaluated/unevaluatedItems.markdown
+++ b/content/2020-12/unevaluated/unevaluatedItems.markdown
@@ -25,9 +25,11 @@ related:
     keyword: unevaluatedProperties
 ---
 
+If no relevant annotations are present, the `unevaluatedItems` subschema must be applied to all locations in the array. If a boolean true value is present from any of the relevant annotations, `unevaluatedItems` is ignored. Otherwise, the subschema must be applied to any index greater than the largest annotation value for `prefixItems`, which does not appear in any annotation value for `contains`.
+
 ## Evaluation
 
-Before delving into `unevaluatedItems`, it's crucial to understand what evaluation means in this context.
+It's crucial to understand what evaluation means in this context.
 
 `unevaluatedItems` considers annotations from `prefixItems`, `items`, and `contains`, both as adjacent keywords and in subschemas of adjacent keywords. Additionally, it is also affected by other `unevaluatedItems` in nested schemas (if present).
 
@@ -35,10 +37,6 @@ Before delving into `unevaluatedItems`, it's crucial to understand what evaluati
 - If any of these keywords generate an annotation for a particular index, that index is considered as evaluated.
 - By definition, the `unevaluatedItems` subschema is always applied after  `prefixItems`, `items`, and `contains` subschemas.
 - As its name implies, `unevaluatedItems` applies to any array index that has not been previously evaluated.
-
-## Explanation
-
-If no relevant annotations are present, the `unevaluatedItems` subschema must be applied to all locations in the array. If a boolean true value is present from any of the relevant annotations, `unevaluatedItems` is ignored. Otherwise, the subschema must be applied to any index greater than the largest annotation value for `prefixItems`, which does not appear in any annotation value for `contains`.
 
 ## Examples
 

--- a/content/2020-12/unevaluated/unevaluatedProperties.markdown
+++ b/content/2020-12/unevaluated/unevaluatedProperties.markdown
@@ -27,9 +27,11 @@ related:
     keyword: unevaluatedItems
 ---
 
+Validation with `unevaluatedProperties` applies only to the child values of instance names that do not appear in the `properties`, `patternProperties`, `additionalProperties`, or `unevaluatedProperties` annotation results that apply to the instance location being validated. For all such properties, validation succeeds if the child instance validates against the `unevaluatedProperties` schema.
+
 ## Evaluation
 
-Before delving into `unevaluatedProperties`, it's crucial to understand what evaluation means in this context.
+It's crucial to understand what evaluation means in this context.
 
 `unevaluatedProperties` considers annotations from `properties`, `patternProperties`, and `additionalProperties`, both as adjacent keywords and in subschemas of adjacent keywords. Additionally, it is also affected by other `unevaluatedProperties` in nested schemas (if present).
 
@@ -37,10 +39,6 @@ Before delving into `unevaluatedProperties`, it's crucial to understand what eva
 - If any of these keywords generate an annotation for a particular property at the same instance location (independently of the schema location), that property is considered as evaluated.
 - By definition, the `unevaluatedProperties` subschema is always applied after `properties`, `patternProperties`, and `additionalProperties` subschemas.
 - As its name implies, `unevaluatedProperties` applies to any object property that has not been previously evaluated.
-
-## Explanation
-
-Validation with `unevaluatedProperties` applies only to the child values of instance names that do not appear in the `properties`, `patternProperties`, `additionalProperties`, or `unevaluatedProperties` annotation results that apply to the instance location being validated. For all such properties, validation succeeds if the child instance validates against the `unevaluatedProperties` schema.
 
 ## Examples
 


### PR DESCRIPTION
Some have an `Explanation` header and some don't. We can assume that any
text here is indeed an explanation and avoid that header everywhere.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
